### PR TITLE
OXT-880: Compilation with GCC 6.3 and GLibc 2.25.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 .libs
 cscope.*
 TAGS
+EXTRAVERSION
+*linux-libtool
 
 # ac/am
 Makefile.in
@@ -25,6 +27,7 @@ Makefile.in
 /m4/
 /missing
 /stamp-h1
+/mk/config.log
 
 # executables
 /drivers/lock-util
@@ -41,6 +44,7 @@ Makefile.in
 /vhd/lib/test/random-copy
 /vhd/lib/test/test-snapshot
 /tapback/tapback
+/cpumond/cpumond
 
 # generated makefiles
 /Makefile
@@ -53,7 +57,8 @@ Makefile.in
 /vhd/lib/Makefile
 /vhd/lib/test/Makefile
 /tapback/Makefile
-mk/config.log
+/cpumond/Makefile
+/drivers/crypto/Makefile
 
 # dist output
 /blktap-*.tar.*

--- a/control/blktap.rules
+++ b/control/blktap.rules
@@ -1,3 +1,2 @@
 SUBSYSTEM=="misc",	KERNEL=="blktap-control",	NAME="blktap/control"
-SUBSYSTEM=="blktap2",	KERNEL=="blktap[0-9]*",		NAME="blktap/%k"
 SUBSYSTEM=="block",	KERNEL=="td[a-z]*",		NAME="%k"

--- a/control/tap-ctl-allocate.c
+++ b/control/tap-ctl-allocate.c
@@ -41,7 +41,7 @@
 #include <getopt.h>
 #include <libgen.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/ioctl.h>
 #include <linux/major.h>
 

--- a/control/tap-ctl.c
+++ b/control/tap-ctl.c
@@ -40,7 +40,7 @@
 #include <signal.h>
 #include <sys/time.h>
 #include <sys/stat.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <errno.h>
 
 #include "tap-ctl.h"

--- a/drivers/block-vhd.c
+++ b/drivers/block-vhd.c
@@ -427,8 +427,8 @@ find_next_free_block(struct vhd_state *s)
 		if (entry != DD_BLK_UNUSED && entry >= s->next_db)
 			s->next_db = (uint64_t)entry + (uint64_t)s->spb
 				+ (uint64_t)s->bm_secs;
-			if (s->next_db > UINT_MAX)
-				break;
+		if (s->next_db > UINT_MAX)
+			break;
 	}
 
 	return 0;
@@ -768,8 +768,8 @@ _vhd_open(td_driver_t *driver, const char *name, td_flag_t flags)
 			      VHD_FLAG_OPEN_QUIET  |
 			      VHD_FLAG_OPEN_RDONLY |
 			      VHD_FLAG_OPEN_NO_CACHE);
-    if (flags & TD_OPEN_LOCAL_CACHE)
-        vhd_flags |= VHD_FLAG_OPEN_LOCAL_CACHE;
+	if (flags & TD_OPEN_LOCAL_CACHE)
+		vhd_flags |= VHD_FLAG_OPEN_LOCAL_CACHE;
 
 	/* pre-allocate for all but NFS and LVM storage */
 	driver->storage = tapdisk_storage_type(name);

--- a/drivers/tapdisk-blktap.c
+++ b/drivers/tapdisk-blktap.c
@@ -40,7 +40,7 @@
 #include <limits.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 
 #include "blktap.h"

--- a/drivers/tapdisk-control.c
+++ b/drivers/tapdisk-control.c
@@ -917,8 +917,8 @@ tapdisk_control_close_image(struct tapdisk_ctl_conn *conn,
 
 out:
 	response->cookie = request->cookie;
-    if (!err)
-        response->type = TAPDISK_MESSAGE_CLOSE_RSP;
+	if (!err)
+		response->type = TAPDISK_MESSAGE_CLOSE_RSP;
 	return err;
 }
 

--- a/drivers/tapdisk-image.c
+++ b/drivers/tapdisk-image.c
@@ -243,9 +243,10 @@ tapdisk_image_open_parent(td_image_t *image, td_image_t **_parent)
 	if (err)
 		return err;
 
-    if (((id.flags & TD_OPEN_NO_O_DIRECT) == TD_OPEN_NO_O_DIRECT) &&
-            ((id.flags & TD_OPEN_LOCAL_CACHE) == TD_OPEN_LOCAL_CACHE))
-        id.flags &= ~TD_OPEN_NO_O_DIRECT;
+	if (((id.flags & TD_OPEN_NO_O_DIRECT) == TD_OPEN_NO_O_DIRECT) &&
+	    ((id.flags & TD_OPEN_LOCAL_CACHE) == TD_OPEN_LOCAL_CACHE))
+		id.flags &= ~TD_OPEN_NO_O_DIRECT;
+
 	err = tapdisk_image_open(id.type, id.name, id.flags, &parent);
 	if (err)
 		return err;

--- a/drivers/tapdisk-vbd.c
+++ b/drivers/tapdisk-vbd.c
@@ -624,13 +624,13 @@ tapdisk_vbd_open_vdi(td_vbd_t *vbd, const char *name, td_flag_t flags, int prt_d
 		}
 	}
 
-    err = vbd_stats_create(vbd);
-    if (err)
-        goto fail;
+	err = vbd_stats_create(vbd);
+	if (err)
+		goto fail;
 
-    err = td_metrics_vdi_start(vbd->tap->minor, &vbd->vdi_stats);
-    if (err)
-        goto fail;
+	err = td_metrics_vdi_start(vbd->tap->minor, &vbd->vdi_stats);
+	if (err)
+		goto fail;
 	if (tmp != vbd->name)
 		free(tmp);
 

--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -583,9 +583,9 @@ tapdisk_xenblkif_connect(domid_t domid, int devid, const grant_ref_t * grefs,
     if (unlikely(err))
         goto fail;
 
-	td_blkif->stoppolling_event = tapdisk_server_register_event(
-			SCHEDULER_POLL_TIMEOUT,	-1, TV_INF,
-			tapdisk_xenblkif_cb_stoppolling, td_blkif);
+    td_blkif->stoppolling_event =
+        tapdisk_server_register_event(SCHEDULER_POLL_TIMEOUT, -1, TV_INF,
+                tapdisk_xenblkif_cb_stoppolling, td_blkif);
     if (unlikely(td_blkif->stoppolling_event < 0)) {
         err = td_blkif->stoppolling_event;
         RING_ERR(td_blkif, "failed to register event: %s\n", strerror(-err));

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -527,16 +527,16 @@ tapdisk_xenblkif_complete_request(struct td_xenblkif * const blkif,
 		xenio_blkif_put_response(blkif, tapreq, _err, final);
 	}
 
-    tapdisk_xenblkif_free_request(blkif, tapreq);
+	tapdisk_xenblkif_free_request(blkif, tapreq);
 
-    blkif->stats.reqs.out++;
-    if (final)
-        blkif->stats.kicks.out++;
+	blkif->stats.reqs.out++;
+	if (final)
+		blkif->stats.kicks.out++;
 
 	if (unlikely(processing_barrier_message))
 		blkif->barrier.msg = NULL;
 
-    /*
+	/*
 	 * Schedule a ring check in case we left requests in it due to lack of
 	 * memory or in case we stopped processing it because of a barrier.
 	 *


### PR DESCRIPTION
- makedev, major, minor, etc are now defined in sys/sysmacros.h;
- Misleading indentation will now trigger warnings.

# Dependencies:
See https://github.com/OpenXT/xenclient-oe/pull/830