### PR TITLE
blktap3: Fix printf() format for portability.

### DIFF
--- a/drivers/td-blkif.c
+++ b/drivers/td-blkif.c
@@ -680,7 +680,7 @@ tapdisk_xenblkif_ring_stats_update(struct td_xenblkif *blkif)
         err = ftruncate(blkif->xenvbd_stats.io_ring.fd, len + sizeof(*chksum));
         if (unlikely(err)) {
             err = errno;
-            EPRINTF("failed to truncate %s to %u: %s\n",
+            EPRINTF("failed to truncate %s to %zu: %s\n",
                     blkif->xenvbd_stats.io_ring.path, len + sizeof(*chksum),
 					strerror(err));
         }

--- a/drivers/td-req.c
+++ b/drivers/td-req.c
@@ -303,7 +303,7 @@ xenio_blkif_put_response(struct td_xenblkif * const blkif,
             if (err < 0) {
                 err = -errno;
                 if (req) {
-                    RING_ERR(blkif, "req %llu: failed to notify event channel: "
+                    RING_ERR(blkif, "req %"PRIu64": failed to notify event channel: "
                             "%s\n", req->msg.id, strerror(-err));
                 } else {
                     RING_ERR(blkif, "failed to notify event channel: %s\n",
@@ -419,7 +419,7 @@ guest_copy2(struct td_xenblkif * const blkif,
 			 * xen/extras/mini-os/include/gnttab.h (header not available to
 			 * user space)
 			 */
-			RING_ERR(blkif, "req %llu: failed to grant-copy segment %d: %d\n",
+			RING_ERR(blkif, "req %"PRIu64": failed to grant-copy segment %d: %d\n",
                     tapreq->msg.id, i, gcopy_seg->status);
 			err = -EIO;
 			goto out;
@@ -494,7 +494,7 @@ tapdisk_xenblkif_complete_request(struct td_xenblkif * const blkif,
 				_err = guest_copy2(blkif, tapreq);
 				if (unlikely(_err)) {
 					err = _err;
-					RING_ERR(blkif, "req %llu: failed to copy from/to guest: "
+					RING_ERR(blkif, "req %"PRIu64": failed to copy from/to guest: "
 							"%s\n", tapreq->msg.id, strerror(-err));
 				}
 			}
@@ -634,7 +634,7 @@ tapdisk_xenblkif_parse_request(struct td_xenblkif * const blkif,
          * must be transferred.
          */
         if (seg->last_sect < seg->first_sect) {
-            RING_ERR(blkif, "req %llu: invalid sectors %d-%d\n",
+            RING_ERR(blkif, "req %"PRIu64": invalid sectors %d-%d\n",
                     req->msg.id, seg->first_sect, seg->last_sect);
             err = EINVAL;
             goto out;
@@ -682,7 +682,7 @@ tapdisk_xenblkif_parse_request(struct td_xenblkif * const blkif,
     if (blkif_rq_wr(&req->msg)) {
         err = guest_copy2(blkif, req);
         if (err) {
-            RING_ERR(blkif, "req %llu: failed to copy from guest: %s\n",
+            RING_ERR(blkif, "req %"PRIu64": failed to copy from guest: %s\n",
                     req->msg.id, strerror(-err));
             goto out;
         }
@@ -749,7 +749,7 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
         vreq->op = TD_OP_WRITE;
         break;
     default:
-        RING_ERR(blkif, "req %llu: invalid request type %d\n",
+        RING_ERR(blkif, "req %"PRIu64": invalid request type %d\n",
                 tapreq->msg.id, tapreq->msg.operation);
         err = EOPNOTSUPP;
         goto out;
@@ -763,7 +763,7 @@ tapdisk_xenblkif_make_vbd_request(struct td_xenblkif * const blkif,
     if (unlikely((tapreq->msg.nr_segments == 0 &&
                 tapreq->msg.operation != BLKIF_OP_WRITE_BARRIER) ||
             tapreq->msg.nr_segments > BLKIF_MAX_SEGMENTS_PER_REQUEST)) {
-        RING_ERR(blkif, "req %llu: bad number of segments in request (%d)\n",
+        RING_ERR(blkif, "req %"PRIu64": bad number of segments in request (%d)\n",
                 tapreq->msg.id, tapreq->msg.nr_segments);
         err = EINVAL;
         goto out;


### PR DESCRIPTION
Use `inttypes.h` macros to support 32/64bit compilation.