### PR TITLE
use control file created by blktap kernel module

### DIFF
--- a/include/blktap.h
+++ b/include/blktap.h
@@ -36,7 +36,7 @@
 #define BLKTAP2_CONTROL_DIR            "/var/run/blktap-control"
 #define BLKTAP2_CONTROL_SOCKET         "ctl"
 #define BLKTAP2_DIRECTORY              "/dev/xen/blktap-2"
-#define BLKTAP2_CONTROL_DEVICE         BLKTAP2_DIRECTORY"/control"
+#define BLKTAP2_CONTROL_DEVICE         "/dev/blktap-control"
 #define BLKTAP2_RING_DEVICE            BLKTAP2_DIRECTORY"/blktap"
 #define BLKTAP2_IO_DEVICE              BLKTAP2_DIRECTORY"/tapdev"
 #define BLKTAP2_ENOSPC_SIGNAL_FILE     "/var/run/tapdisk-enospc"

--- a/include/blktap2.h
+++ b/include/blktap2.h
@@ -54,7 +54,7 @@
 #define BLKTAP2_CONTROL_DIR            "/var/run/blktap-control"
 #define BLKTAP2_CONTROL_SOCKET         "ctl"
 #define BLKTAP2_DIRECTORY              "/dev/xen/blktap-2"
-#define BLKTAP2_CONTROL_DEVICE         BLKTAP2_DIRECTORY"/control"
+#define BLKTAP2_CONTROL_DEVICE         "/dev/blktap-control"
 #define BLKTAP2_RING_DEVICE            BLKTAP2_DIRECTORY"/blktap"
 #define BLKTAP2_IO_DEVICE              BLKTAP2_DIRECTORY"/tapdev"
 #define BLKTAP2_ENOSPC_SIGNAL_FILE     "/var/run/tapdisk-enospc"


### PR DESCRIPTION
Instead of creating a new control file for ioctl, use the one that
is already created by blktap kernel module for this purpose.

Signed-off-by: Mahantesh Salimath <mahantesh.openxt@gmail.com>